### PR TITLE
Update RestfulGormUrlMappings.groovy

### DIFF
--- a/grails-app/conf/RestfulGormUrlMappings.groovy
+++ b/grails-app/conf/RestfulGormUrlMappings.groovy
@@ -1,5 +1,5 @@
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
-
+// Grails < 2.4 import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import grails.util.Holders
 @SuppressWarnings("deprecation")
 class RestfulUrlUrlMappings {
 	static mappings = {


### PR DESCRIPTION
With the release of Grails 2.4 the static holders have been deprecated. 
From the [documentation](http://grails.github.io/grails-doc/2.4.3/guide/upgradingFrom23.html):

> Static Holder Classes
> 
> The following deprecated classes have been removed from Grails 2.4.x:
> 
>    org.codehaus.groovy.grails.commons.ApplicationHolder
>   org.codehaus.groovy.grails.commons.ConfigurationHolder
>    org.codehaus.groovy.grails.plugins.PluginManagerHolder
>    org.codehaus.groovy.grails.web.context.ServletContextHolder
>    org.codehaus.groovy.grails.compiler.support.GrailsResourceLoaderHolder
> 
> If you or any plugins you have installed are using these classes you will get a compilation error. The problem can be rectified by updating to new plugins and using grails.util.Holders instead.
